### PR TITLE
Fix history store path resolution

### DIFF
--- a/helpers/history_store.py
+++ b/helpers/history_store.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
 import json
-import os
 import time
+from pathlib import Path
 from typing import Any, Dict
 
 
-BASE_DIR = os.path.join(os.getcwd(), "data", "history")
+# Resolve history directory relative to the repository root rather than the
+# current working directory. Using ``os.getcwd()`` meant that importing this
+# module from another location would write files outside the project tree.
+# ``__file__`` always points to this module so we build paths from it.
+BASE_DIR = Path(__file__).resolve().parent.parent / "data" / "history"
 
 
-def _ensure_dir(path: str) -> None:
-    os.makedirs(path, exist_ok=True)
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
 
 
 def write_event(stream: str, data: Dict[str, Any]) -> str:
     ts = int(time.time() * 1000)
-    dir_path = os.path.join(BASE_DIR, stream)
+    dir_path = BASE_DIR / stream
     _ensure_dir(dir_path)
-    file_path = os.path.join(dir_path, f"{ts}.json")
+    file_path = dir_path / f"{ts}.json"
     with open(file_path, "w") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
-    return file_path
+    return str(file_path)

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -1,0 +1,16 @@
+import sys
+import importlib
+from pathlib import Path
+
+
+def test_write_event_uses_repo_root(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    # Change to another directory before importing history_store
+    monkeypatch.chdir(tmp_path)
+    sys.path.insert(0, str(repo_root))
+    hs = importlib.import_module("helpers.history_store")
+    file_path = hs.write_event("sample", {"foo": "bar"})
+    expected_dir = repo_root / "data" / "history" / "sample"
+    fp = Path(file_path)
+    assert fp.is_file()
+    assert fp.is_relative_to(expected_dir)


### PR DESCRIPTION
## Summary
- ensure history store writes events relative to repo root instead of current working directory
- add regression test verifying event path is anchored to project directory

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689706ae12f48326a72bebdf1b9d27d7